### PR TITLE
Image size on astro gallery

### DIFF
--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -20,19 +20,14 @@ const { items } = Astro.props;
         href={item.image.src}
         target="_blank"
         rel="noreferrer"
+        data-pswp-width={item.image.width}
+        data-pswp-height={item.image.height}
       >
         <Image src={item.image} alt={item.alt} width={200}/>
       </a>
     )
   })}
 </div>
-
-
-<style is:global>
-  .pswp__img {
-    object-fit: contain;
-  }
-</style>
 
 <script>
 	import PhotoSwipeLightbox from "photoswipe/lightbox";


### PR DESCRIPTION
# Pull request

Mejora la visualización de la galeria agregando el tamaño de la imagen

## Observaciones

La animación funciona, a diferencia del workaround implementado que hace que haga unos saltos muy raros

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/7fbf7b90-b913-47e3-9b34-839920612302" />

