### PR TITLE
getStaticPaths con funciones getEntriesPaths y getTagsPaths

### DIFF
--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -4,9 +4,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import Comments from '@components/Comments.astro';
-import { getEntriesPaths, type EntriesPath } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
 
-export async function getStaticPaths(): Promise<EntriesPath<'blog'>[]>  {
+export async function getStaticPaths(): EntriesStaticPaths<'blog'>  {
   return getEntriesPaths('blog')
 };
 

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -4,7 +4,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import Comments from '@components/Comments.astro';
-import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils/paths';
 
 export async function getStaticPaths(): EntriesStaticPaths<'blog'>  {
   return getEntriesPaths('blog')

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -4,9 +4,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import Comments from '@components/Comments.astro';
-import { getEntriesPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesPath } from 'src/utils';
 
-export const getStaticPaths = async () => {
+export async function getStaticPaths(): Promise<EntriesPath<'blog'>[]>  {
   return getEntriesPaths('blog')
 };
 

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,19 +1,14 @@
 ---
-import type { InferGetStaticPropsType, GetStaticPaths } from 'astro';
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import Comments from '@components/Comments.astro';
+import { getEntriesPaths } from 'src/utils';
 
-export const getStaticPaths = (async () => {
-  const blogEntries = await getCollection('blog');
-  return blogEntries.map(entry => ({
-    params: { id: entry.id }, props: { entry },
-  }));
-}) satisfies GetStaticPaths
-
-type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+export const getStaticPaths = async () => {
+  return getEntriesPaths('blog')
+};
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,29 +1,16 @@
 ---
-import type { InferGetStaticParamsType, InferGetStaticPropsType, GetStaticPaths } from 'astro';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
-import { getCollection } from 'astro:content';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
+import { getTagsPaths } from 'src/utils';
 
-export const getStaticPaths = (async () => {
-  const allPosts = (await getCollection('blog')).sort((a, b)=> b.id.localeCompare(a.id));
-  const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())].sort((a, b)=> a.localeCompare(b));
+export async function getStaticPaths() {
+  return getTagsPaths('blog')
+}
 
-  return uniqueTags.map((tag) => {
-    const filteredPosts = allPosts.filter((post) => post.data.tags.includes(tag));
-    return {
-      params: { tag },
-      props: { posts: filteredPosts, tags: uniqueTags },
-    };
-  });
-}) satisfies GetStaticPaths
-
-type Params = InferGetStaticParamsType<typeof getStaticPaths>;
-type Props = InferGetStaticPropsType<typeof getStaticPaths>;
-
-const { tag } = Astro.params as Params;
-const { posts, tags } = Astro.props as Props;
+const { tag } = Astro.params;
+const { posts, tags } = Astro.props;
 ---
 <BaseLayout pageTitle={tag}>
   <BlogTags route="/blog/tags/" tags={tags} current={tag}/>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -3,9 +3,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
-import { getTagsPaths } from 'src/utils';
+import { getTagsPaths, type TagsPath } from 'src/utils';
 
-export async function getStaticPaths() {
+export async function getStaticPaths(): Promise<TagsPath<'blog'>[]>  {
   return getTagsPaths('blog')
 }
 

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -3,7 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
-import { getTagsPaths, type TagsStaticPaths } from 'src/utils';
+import { getTagsPaths, type TagsStaticPaths } from 'src/utils/paths';
 
 export async function getStaticPaths(): TagsStaticPaths<'blog'>  {
   return getTagsPaths('blog')

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -3,9 +3,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
-import { getTagsPaths, type TagsPath } from 'src/utils';
+import { getTagsPaths, type TagsStaticPaths } from 'src/utils';
 
-export async function getStaticPaths(): Promise<TagsPath<'blog'>[]>  {
+export async function getStaticPaths(): TagsStaticPaths<'blog'>  {
   return getTagsPaths('blog')
 }
 

--- a/src/pages/charla/[...id].astro
+++ b/src/pages/charla/[...id].astro
@@ -4,9 +4,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import ResponsiveIframe from '@components/ResponsiveIframe.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
-import { getEntriesPaths, type EntriesPath } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
 
-export async function getStaticPaths(): Promise<EntriesPath<'talk'>[]>  {
+export async function getStaticPaths(): EntriesStaticPaths<'talk'>  {
   return getEntriesPaths('talk')
 };
 

--- a/src/pages/charla/[...id].astro
+++ b/src/pages/charla/[...id].astro
@@ -1,19 +1,14 @@
 ---
-import type { InferGetStaticPropsType, GetStaticPaths } from 'astro';
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import ResponsiveIframe from '@components/ResponsiveIframe.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
+import { getEntriesPaths } from 'src/utils';
 
-export const getStaticPaths = (async () => {
-  const blogEntries = await getCollection('talk');
-  return blogEntries.map(entry => ({
-    params: { id: entry.id }, props: { entry },
-  }));
-}) satisfies GetStaticPaths
-
-type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+export const getStaticPaths = async () => {
+  return getEntriesPaths('talk')
+};
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);

--- a/src/pages/charla/[...id].astro
+++ b/src/pages/charla/[...id].astro
@@ -4,9 +4,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import ResponsiveIframe from '@components/ResponsiveIframe.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
-import { getEntriesPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesPath } from 'src/utils';
 
-export const getStaticPaths = async () => {
+export async function getStaticPaths(): Promise<EntriesPath<'talk'>[]>  {
   return getEntriesPaths('talk')
 };
 

--- a/src/pages/charla/[...id].astro
+++ b/src/pages/charla/[...id].astro
@@ -4,7 +4,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogTags from '@components/BlogTags.astro';
 import ResponsiveIframe from '@components/ResponsiveIframe.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
-import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils/paths';
 
 export async function getStaticPaths(): EntriesStaticPaths<'talk'>  {
   return getEntriesPaths('talk')

--- a/src/pages/charla/tags/[tag].astro
+++ b/src/pages/charla/tags/[tag].astro
@@ -3,7 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
-import { getTagsPaths, type TagsStaticPaths } from 'src/utils';
+import { getTagsPaths, type TagsStaticPaths } from 'src/utils/paths';
 
 export async function getStaticPaths(): TagsStaticPaths<'talk'>  {
   return getTagsPaths('talk')

--- a/src/pages/charla/tags/[tag].astro
+++ b/src/pages/charla/tags/[tag].astro
@@ -3,9 +3,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
-import { getTagsPaths, type TagsPath } from 'src/utils';
+import { getTagsPaths, type TagsStaticPaths } from 'src/utils';
 
-export async function getStaticPaths(): Promise<TagsPath<'talk'>[]>  {
+export async function getStaticPaths(): TagsStaticPaths<'talk'>  {
   return getTagsPaths('talk')
 }
 

--- a/src/pages/charla/tags/[tag].astro
+++ b/src/pages/charla/tags/[tag].astro
@@ -1,29 +1,16 @@
 ---
-import type { InferGetStaticParamsType, InferGetStaticPropsType, GetStaticPaths } from 'astro';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
-import { getCollection } from 'astro:content';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
+import { getTagsPaths } from 'src/utils';
 
-export const getStaticPaths = (async () => {
-  const allPosts = (await getCollection('talk')).sort((a, b)=> b.id.localeCompare(a.id));
-  const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())].sort((a, b)=> a.localeCompare(b));
+export async function getStaticPaths() {
+  return getTagsPaths('talk')
+}
 
-  return uniqueTags.map((tag) => {
-    const filteredPosts = allPosts.filter((post) => post.data.tags.includes(tag));
-    return {
-      params: { tag },
-      props: { posts: filteredPosts, tags: uniqueTags },
-    };
-  });
-}) satisfies GetStaticPaths
-
-type Params = InferGetStaticParamsType<typeof getStaticPaths>;
-type Props = InferGetStaticPropsType<typeof getStaticPaths>;
-
-const { tag } = Astro.params as Params;
-const { posts, tags } = Astro.props as Props;
+const { tag } = Astro.params;
+const { posts, tags } = Astro.props;
 ---
 <BaseLayout pageTitle={tag}>
   <BlogTags route="/charla/tags/" tags={tags} current={tag}/>

--- a/src/pages/charla/tags/[tag].astro
+++ b/src/pages/charla/tags/[tag].astro
@@ -3,9 +3,9 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogPost from '@components/BlogPost.astro';
 import { dateFormat } from 'src/scripts/dateFormat';
 import BlogTags from '@components/BlogTags.astro';
-import { getTagsPaths } from 'src/utils';
+import { getTagsPaths, type TagsPath } from 'src/utils';
 
-export async function getStaticPaths() {
+export async function getStaticPaths(): Promise<TagsPath<'talk'>[]>  {
   return getTagsPaths('talk')
 }
 

--- a/src/pages/comunidad/[...id].astro
+++ b/src/pages/comunidad/[...id].astro
@@ -3,7 +3,7 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils/paths';
 
 export async function getStaticPaths(): EntriesStaticPaths<'community'> {
   return await getEntriesPaths('community');

--- a/src/pages/comunidad/[...id].astro
+++ b/src/pages/comunidad/[...id].astro
@@ -3,13 +3,11 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesPath } from 'src/utils';
 
-// 1. Generate a new path for every collection entry
-export async function getStaticPaths() {
-  return getEntriesPaths('community')
+export async function getStaticPaths(): Promise<EntriesPath<'projects'>[]> {
+  return await getEntriesPaths('community');
 }
-// 2. For your template, you can get the entry directly from the prop
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 

--- a/src/pages/comunidad/[...id].astro
+++ b/src/pages/comunidad/[...id].astro
@@ -3,9 +3,9 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths, type EntriesPath } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
 
-export async function getStaticPaths(): Promise<EntriesPath<'projects'>[]> {
+export async function getStaticPaths(): EntriesStaticPaths<'community'> {
   return await getEntriesPaths('community');
 }
 const { entry } = Astro.props;

--- a/src/pages/comunidad/[...id].astro
+++ b/src/pages/comunidad/[...id].astro
@@ -1,15 +1,13 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
+import { getEntriesPaths } from 'src/utils';
 
 // 1. Generate a new path for every collection entry
 export async function getStaticPaths() {
-  const entries = await getCollection('community');
-  return entries.map(entry => ({
-    params: { id: entry.id }, props: { entry },
-  }));
+  return getEntriesPaths('community')
 }
 // 2. For your template, you can get the entry directly from the prop
 const { entry } = Astro.props;

--- a/src/pages/proyecto/[...id].astro
+++ b/src/pages/proyecto/[...id].astro
@@ -3,9 +3,9 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesPath } from 'src/utils';
 
-export async function getStaticPaths() {
+export async function getStaticPaths(): Promise<EntriesPath<'projects'>[]>  {
   return getEntriesPaths('projects')
 }
 const { entry } = Astro.props;

--- a/src/pages/proyecto/[...id].astro
+++ b/src/pages/proyecto/[...id].astro
@@ -3,7 +3,7 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils/paths';
 
 export async function getStaticPaths(): EntriesStaticPaths<'projects'>  {
   return getEntriesPaths('projects')

--- a/src/pages/proyecto/[...id].astro
+++ b/src/pages/proyecto/[...id].astro
@@ -1,17 +1,13 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
+import { getEntriesPaths } from 'src/utils';
 
-// 1. Generate a new path for every collection entry
 export async function getStaticPaths() {
-  const entries = await getCollection('projects');
-  return entries.map(entry => ({
-    params: { id: entry.id }, props: { entry },
-  }));
+  return getEntriesPaths('projects')
 }
-// 2. For your template, you can get the entry directly from the prop
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 

--- a/src/pages/proyecto/[...id].astro
+++ b/src/pages/proyecto/[...id].astro
@@ -3,9 +3,9 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths, type EntriesPath } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
 
-export async function getStaticPaths(): Promise<EntriesPath<'projects'>[]>  {
+export async function getStaticPaths(): EntriesStaticPaths<'projects'>  {
   return getEntriesPaths('projects')
 }
 const { entry } = Astro.props;

--- a/src/pages/trabajo/[...id].astro
+++ b/src/pages/trabajo/[...id].astro
@@ -3,10 +3,10 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesPath } from 'src/utils';
 export const dateFormat = new Intl.DateTimeFormat("es-CO", { month: "long", year: "numeric", timeZone: 'UTC' });
 
-export async function getStaticPaths() {
+export async function getStaticPaths(): Promise<EntriesPath<'work'>[]>  {
   return getEntriesPaths('work')
 }
 const { entry } = Astro.props;

--- a/src/pages/trabajo/[...id].astro
+++ b/src/pages/trabajo/[...id].astro
@@ -1,18 +1,14 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
+import { getEntriesPaths } from 'src/utils';
 export const dateFormat = new Intl.DateTimeFormat("es-CO", { month: "long", year: "numeric", timeZone: 'UTC' });
 
-// 1. Generate a new path for every collection entry
 export async function getStaticPaths() {
-  const workEntries = await getCollection('work');
-  return workEntries.map(entry => ({
-    params: { id: entry.id }, props: { entry },
-  }));
+  return getEntriesPaths('work')
 }
-// 2. For your template, you can get the entry directly from the prop
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 ---

--- a/src/pages/trabajo/[...id].astro
+++ b/src/pages/trabajo/[...id].astro
@@ -3,7 +3,7 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils/paths';
 export const dateFormat = new Intl.DateTimeFormat("es-CO", { month: "long", year: "numeric", timeZone: 'UTC' });
 
 export async function getStaticPaths(): EntriesStaticPaths<'work'>  {

--- a/src/pages/trabajo/[...id].astro
+++ b/src/pages/trabajo/[...id].astro
@@ -3,10 +3,10 @@ import { render } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { Image } from "astro:assets";
 import Gallery from '@components/Gallery.astro';
-import { getEntriesPaths, type EntriesPath } from 'src/utils';
+import { getEntriesPaths, type EntriesStaticPaths } from 'src/utils';
 export const dateFormat = new Intl.DateTimeFormat("es-CO", { month: "long", year: "numeric", timeZone: 'UTC' });
 
-export async function getStaticPaths(): Promise<EntriesPath<'work'>[]>  {
+export async function getStaticPaths(): EntriesStaticPaths<'work'>  {
   return getEntriesPaths('work')
 }
 const { entry } = Astro.props;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,23 @@
+import { getCollection } from "astro:content";
+import type { CollectionKey } from "astro:content";
+type CollectionWithTags = 'blog'|'talk'
+
+export const getEntriesPaths = async (collectionName: CollectionKey) => {
+  const entries = await getCollection(collectionName);
+  return entries.map(entry => ({
+    params: { id: entry.id }, props: { entry },
+  }));
+}
+
+export const getTagsPaths = async (collectionName: CollectionWithTags) => {
+  const allPosts = (await getCollection(collectionName)).sort((a, b)=> b.id.localeCompare(a.id));
+  const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())].sort((a, b)=> a.localeCompare(b));
+
+  return uniqueTags.map((tag) => {
+    const filteredPosts = allPosts.filter((post) => post.data.tags.includes(tag));
+    return {
+      params: { tag },
+      props: { posts: filteredPosts, tags: uniqueTags },
+    };
+  });
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,35 @@
 import { getCollection } from "astro:content";
-import type { CollectionKey } from "astro:content";
+import type { CollectionEntry, CollectionKey } from "astro:content";
 type CollectionWithTags = 'blog'|'talk'
 
-export const getEntriesPaths = async (collectionName: CollectionKey) => {
-  const entries = await getCollection(collectionName);
+export type EntriesPath<C extends CollectionKey> =  {
+  params: {
+    id: string
+  },
+  props: {
+    entry: CollectionEntry<C>
+  }
+}
+
+export type TagsPath<C extends CollectionWithTags> =  {
+  params: {
+    tag: string
+  },
+  props: {
+    posts: CollectionEntry<C>[],
+    tags: string[]
+  }
+}
+
+export const getEntriesPaths = async (collectionName: CollectionKey): Promise<EntriesPath<CollectionKey>[]> =>  {
+  const entries: CollectionEntry<CollectionKey>[] = await getCollection<CollectionKey>(collectionName);
   return entries.map(entry => ({
     params: { id: entry.id }, props: { entry },
   }));
 }
 
-export const getTagsPaths = async (collectionName: CollectionWithTags) => {
-  const allPosts = (await getCollection(collectionName)).sort((a, b)=> b.id.localeCompare(a.id));
+export async function getTagsPaths<C extends CollectionWithTags>(collectionName: C): Promise<TagsPath<CollectionWithTags>[]> {
+  const allPosts = (await getCollection<CollectionWithTags>(collectionName)).sort((a, b)=> b.id.localeCompare(a.id));
   const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())].sort((a, b)=> a.localeCompare(b));
 
   return uniqueTags.map((tag) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,14 +21,17 @@ export type TagsPath<C extends CollectionWithTags> =  {
   }
 }
 
-export const getEntriesPaths = async (collectionName: CollectionKey): Promise<EntriesPath<CollectionKey>[]> =>  {
+export type EntriesStaticPaths<C extends CollectionKey> = Promise<EntriesPath<C>[]>
+export type TagsStaticPaths<C extends CollectionWithTags> = Promise<TagsPath<C>[]>
+
+export const getEntriesPaths = async (collectionName: CollectionKey): EntriesStaticPaths<CollectionKey> =>  {
   const entries: CollectionEntry<CollectionKey>[] = await getCollection<CollectionKey>(collectionName);
   return entries.map(entry => ({
     params: { id: entry.id }, props: { entry },
   }));
 }
 
-export async function getTagsPaths<C extends CollectionWithTags>(collectionName: C): Promise<TagsPath<CollectionWithTags>[]> {
+export async function getTagsPaths(collectionName: CollectionWithTags): TagsStaticPaths<CollectionWithTags> {
   const allPosts = (await getCollection<CollectionWithTags>(collectionName)).sort((a, b)=> b.id.localeCompare(a.id));
   const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())].sort((a, b)=> a.localeCompare(b));
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -24,6 +24,12 @@ export type TagsPath<C extends CollectionWithTags> =  {
 export type EntriesStaticPaths<C extends CollectionKey> = Promise<EntriesPath<C>[]>
 export type TagsStaticPaths<C extends CollectionWithTags> = Promise<TagsPath<C>[]>
 
+
+/**
+ * Generates the static paths of any entry page
+ * @param collectionName should be any CollectionKey defined on astro.config.mjs
+ * @returns A promise with the Entries paths
+ */
 export const getEntriesPaths = async (collectionName: CollectionKey): EntriesStaticPaths<CollectionKey> =>  {
   const entries: CollectionEntry<CollectionKey>[] = await getCollection<CollectionKey>(collectionName);
   return entries.map(entry => ({
@@ -31,6 +37,11 @@ export const getEntriesPaths = async (collectionName: CollectionKey): EntriesSta
   }));
 }
 
+/**
+ * Generates the static paths of a tags page
+ * @param collectionName should be a collection that has tags for example 'blog' or 'talk'
+ * @returns A promise with the Tags paths
+ */
 export async function getTagsPaths(collectionName: CollectionWithTags): TagsStaticPaths<CollectionWithTags> {
   const allPosts = (await getCollection<CollectionWithTags>(collectionName)).sort((a, b)=> b.id.localeCompare(a.id));
   const uniqueTags = [...new Set(allPosts.map((post) => post.data.tags).flat())].sort((a, b)=> a.localeCompare(b));


### PR DESCRIPTION
## Observaciones

Creadas funciones de utilidad que evita el codigo repetido de getStaticPaths haciendo uso de generics

https://docs.astro.build/es/reference/api-reference/#collectionkey