### PR TITLE
ThemeIcon color corregido, fondo y hover

### DIFF
--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -34,8 +34,11 @@ const { duration = '500ms' } = Astro.props;
 <style define:vars={{ duration }}>
   .theme-toggle {
     width: 100%;
-    color: var(--colors-sidebar-hover);
+    color: var(--colors-sidebar-text);
     --theme-toggle__expand--duration: var(--duration);
+  }
+  .theme-toggle:hover {
+    color: var(--colors-sidebar-hover);
   }
   .theme-toggle__expand g circle,
   .theme-toggle__expand g path {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,7 +16,7 @@
   --colors-heading: #1F1E24;
   --colors-blogBg: #eee;
   --colors-sidebar-background: #004f53;
-  --colors-sidebar-color: #fff;
+  --colors-sidebar-text: #fff;
   --colors-sidebar-hover: #B8FFFF;
 }
 
@@ -155,7 +155,7 @@ Sidebar
   font-size: 1.2rem;
   font-weight: 500;
   background: var(--colors-sidebar-background);
-  color: var(--colors-sidebar-color);
+  color: var(--colors-sidebar-text);
   font-family: "Ubuntu", sans-serif;
   text-decoration: none;
   display: flex;


### PR DESCRIPTION
# Pull request

Corrije el color en que aparece el icono del sidebar

El icono siempre aparece seleccionado
<img width="277" alt="image" src="https://github.com/user-attachments/assets/99cb9075-30cd-419f-9360-68d230b3c8f7" />


## Observaciones

Colocar la información que considere pertinente del cambio que se está subiendo, por ejemplo una captura de pantalla si es algún cambio visual que quiera resaltar.
