### PR TITLE
Cambio de color para resaltado de código

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,5 +13,13 @@ export default defineConfig({
     '/blog/2018-09-17-patrones-automatizacion-pruebas': '/charla/2018-09-17-patrones-automatizacion-pruebas',
     '/blog/2017-01-30-test-unitarios': '/charla/2017-01-30-test-unitarios'
   },
-  integrations: [sitemap()]
+  integrations: [sitemap()],
+  markdown: {
+    shikiConfig: {
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark',
+      },
+    },
+  },
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -378,3 +378,13 @@ Sidebar
     transform: translateX(-100%);
   }
 }
+
+html.dark .astro-code,
+html.dark .astro-code span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  /* Optional, if you also want font styles */
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}


### PR DESCRIPTION
# Pull request

Cambio de color en resaltado de código

## Observaciones

Asi se veia el tema claro

<img width="891" alt="image" src="https://github.com/user-attachments/assets/6df24a3f-9b86-4835-a9a3-1627dbce6bba" />

Y asi se ve con estos cambios
![image](https://github.com/user-attachments/assets/49e4de13-5f9d-49de-a51e-53db07d86cd1)

