### PR TITLE
Reglas mas estrictas de lint

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,43 @@
 
  - Copilot: when generating or refactoring content with assistance, ensure the output includes complete frontmatter and that the suggested filename respects the date prefix. Do not accept suggestions for posts without a date-prefixed filename. Additionally, Copilot must not introduce the TypeScript `any` type in generated code; always prefer explicit types or interfaces.
 
+- Copilot: when generating or refactoring content with assistance, ensure the output includes complete frontmatter and that the suggested filename respects the date prefix. Do not accept suggestions for posts without a date-prefixed filename.
+- **Types (strict)**: Copilot must never introduce the TypeScript `any` type in generated code. The project enforces `@typescript-eslint/no-explicit-any` as `error` in ESLint. If Copilot proposes `any`, reject the suggestion and prefer one of the following:
+  - a concrete interface/type declaration, or
+  - a generic type parameter (e.g., `T`) with a TODO comment linking to an issue for narrowing the type later, or
+  - a small union or unknown-to-typed conversion with an explicit cast and a documented justification.
+
+  Never use `as any` or broad `any` aliases. If an exceptional case genuinely cannot be typed (extraordinary legacy interop), create a short issue in the repo tracking the exception and reference it in the code comment.
+
+- **`@ts-ignore` and variant comments**: `@ts-ignore`, `// @ts-expect-error`, `// @ts-nocheck` are highly restricted. Prefer fixing types instead of silencing the checker. If an ignore is unavoidable:
+  - use `// @ts-expect-error` only with a one-line description of why and a link to an issue (minimum 10 characters), and
+  - avoid `// @ts-ignore`; if used, it must be converted to an issue and justified in the comment as above.
+
+- **Triple-slash references**: triple-slash references are allowed in `.d.ts` declaration files where necessary (for example to consume generated `.astro` types). Prefer adding an ESLint override for `*.d.ts` instead of inline disables.
+
 - Default site language: Spanish (`es`). When the language is not explicitly specified, prefer Spanish for authoring content and suggested slugs. Contributors should still provide translations and set `translation_status` appropriately.
+
+---
+
+*Nota:* se ha reforzado la política de tipos: `any` está prohibido en el código de `src/` y ESLint lo marca como `error`. Para excepciones temporales en tests o carpetas legacy, documentar el caso y abrir un issue que lo rastree.
+
+## Política de excepciones y technical debt (acuerdo)
+
+No crear issues individuales por cada excepción temporal. En su lugar, usar el siguiente patrón inline para marcar deuda técnica que debe revisarse posteriormente:
+
+```ts
+// TODO(debt): <razón breve> — owner: @usuario — until: YYYY-MM-DD
+```
+
+Reglas:
+- El comentario debe aparecer inmediatamente arriba de la línea o bloque afectado.
+- `owner` es el @usuario responsable temporalmente del arreglo (puede ser un equipo).
+- `until` es la fecha estimada para revisar o remediar la deuda.
+- No usar `as any` ni `// eslint-disable` sin este TODO; si una excepción es absolutamente necesaria, debe acompañarse del TODO.
+
+Centralizar los ítems en `docs/tech-debt.md` — el comentario inline actuará como punto de referencia y la lista en `docs/tech-debt.md` servirá como único lugar para seguimiento y revisiones periódicas.
+
+Si una deuda técnica necesita más contexto, agregar una entrada en `docs/tech-debt.md` con más detalles en lugar de crear un issue por cada caso.
 
 ---
 

--- a/cypress/e2e/stubs.ts
+++ b/cypress/e2e/stubs.ts
@@ -1,6 +1,5 @@
 const colorMode = (isDark: boolean, isMedia: boolean) => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onBeforeLoad (win: any) {
+  onBeforeLoad (win: Window & { matchMedia?: (q: string) => { matches: boolean } }) {
     const callback = cy.stub(win, 'matchMedia')
     callback.withArgs('(prefers-color-scheme: dark)')
       .as(`dark-mode ${isDark}`)

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,0 +1,42 @@
+# Technical Debt Tracker
+
+Este archivo centraliza las excepciones temporales y deuda técnica marcada en el
+repositorio. No se crean issues por cada excepción: los comentarios inline
+(`TODO(debt): ...`) en el código sirven como referencia y deben reflejarse
+en esta lista cuando requieren seguimiento.
+
+Formato de entrada
+- **id**: identificador corto (p. ej. `debt-001`)
+- **archivo**: ruta al archivo donde aparece
+- **línea / contexto**: resumen breve del lugar
+- **razón**: por qué se aceptó la excepción temporal
+- **owner**: responsable temporal (@usuario)
+- **until**: fecha objetivo para revisar
+- **estado**: `open` | `in-progress` | `closed`
+
+Ejemplo
+
+- id: debt-001
+  archivo: `cypress/e2e/stubs.ts`
+  línea / contexto: `onBeforeLoad` stub de `matchMedia`
+  razón: Test legacy depende de Cypress; plan de migración a Playwright en curso
+  owner: @scot3004
+  until: 2026-05-01
+  estado: open
+
+Cómo usar
+1. Añadir el comentario inline en el código con el formato:
+
+```ts
+// TODO(debt): <razón breve> — owner: @usuario — until: YYYY-MM-DD
+```
+
+2. Añadir o actualizar la entrada correspondiente en este archivo con detalles
+   adicionales si el ítem requiere seguimiento.
+
+3. En la revisión de sprint o cada mes, revisar las entradas `open` y moverlas
+   a `in-progress` o `closed` según corresponda.
+
+Notas
+- Este archivo es la fuente de verdad para deuda técnica. Evitar crear issues
+  por cada excepción para mantener el backlog limpio.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,11 @@ const sharedSettings = {
 const sharedRules = {
   'import/no-unresolved': 'error',
   'import/no-extraneous-dependencies': ['error', { devDependencies: ['cypress/**', 'tests/**', '**/*.spec.*', 'playwright.config.ts', 'vitest.config.ts'] }],
-  'indent': ['error', 2, { SwitchCase: 1 }]
+  'indent': ['error', 2, { SwitchCase: 1 }],
+  'no-warning-comments': [
+    'warn',
+    { terms: ['ts-ignore'], location: 'anywhere' }
+  ],
 }
 
 export default [
@@ -42,7 +46,7 @@ export default [
     rules: {
       ...sharedRules,
       ...tsPlugin.configs.recommended.rules,
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {


### PR DESCRIPTION
# Pull request

Closes #91 
## Observaciones

Se implementa verificaciones en la rama para prohibir el uso de any y algunos documentos que reflejan la deuda tecnica
