### PR TITLE
Implementado markdownlint

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  // Paths ignored by markdownlint-cli2 (supports glob patterns)
+  "ignores": [
+    "node_modules/**",
+    "coverage/**",
+    "playwright-report/**",
+    "test-results/**",
+    ".netlify/**"
+  ]
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,79 @@
+// Markdownlint configuration
+// Rules are configured with severity levels:
+// - severity: "warning": reported but doesn't fail (non-blocking)
+// - severity: "error": fails validation (default, if not specified)
+
+// WARNINGS: Non-blocking formatting suggestions (for compatibility with existing content)
+{
+  "blanks-around-fences": {
+    "severity": "warning"
+  },
+  "blanks-around-headings": {
+    "severity": "warning"
+  },
+  "blanks-around-lists": {
+    "severity": "warning"
+  },
+  "blanks-around-tables": {
+    "severity": "warning"
+  },
+  "code-block-style": {
+    "severity": "warning"
+  },
+  "line-length": {
+    "severity": "warning",
+    "line_length": 120
+  },
+  "list-indent": {
+    "severity": "warning"
+  },
+  "fenced-code-language": {
+    "severity": "warning"
+  },
+  "first-line-heading": {
+    "severity": "warning"
+  },
+  "heading-style": {
+    "severity": "warning"
+  },
+  "no-bare-urls": {
+    "severity": "warning"
+  },
+  "no-duplicate-heading": {
+    "severity": "warning"
+  },
+  "no-emphasis-as-heading": {
+    "severity": "warning"
+  },
+  "no-inline-html": {
+    // Allowed elements for inline HTML in content
+    "allowed_elements": ["a", "img"]
+  },
+  "no-multiple-blanks": {
+    "severity": "warning"
+  },
+  "no-multiple-space-atx": {
+    "severity": "warning"
+  },
+  "no-trailing-punctuation": {
+    "severity": "warning"
+  },
+  "no-trailing-spaces": {
+    "severity": "warning"
+  },
+  "ol-prefix": {
+    "severity": "warning"
+  },
+  "single-title": {
+    "severity": "warning"
+  },
+  "table-column-style": {
+    "severity": "warning"
+  },
+  "ul-indent": {
+    "severity": "warning"
+  },
+  "ul-style": {
+    "severity": "warning"
+  }
+}

--- a/docs/MARKDOWN_VALIDATION.md
+++ b/docs/MARKDOWN_VALIDATION.md
@@ -37,8 +37,8 @@ Arregla automáticamente los problemas que se puedan corregir (espacios, formato
 Para validar un archivo o carpeta específica:
 
 ```bash
-npx markdownlint-cli2 'path/to/file.md'
-npx markdownlint-cli2 'docs/**/*.md'
+npx markdownlint-cli2 "path/to/file.md"
+npx markdownlint-cli2 "docs/**/*.md"
 ```
 
 ## Integración con CI/CD

--- a/docs/MARKDOWN_VALIDATION.md
+++ b/docs/MARKDOWN_VALIDATION.md
@@ -1,4 +1,5 @@
 # Markdownlint: Validación de Markdown
+
 Este documento contiene los comandos mínimos para validar Markdown en el proyecto.
 
 Comandos
@@ -8,7 +9,9 @@ Comandos
 
 Nota CI
 
-El CI ejecuta `npm run lint` (que incluye `lint:md`).
+En el pipeline de CI para `push` y `pull_request`
+se ejecuta `npm run lint` (que incluye `lint:md`).
+En ejecuciones manuales (`workflow_dispatch`), este paso puede omitirse.
 
 Validación puntual
 

--- a/docs/MARKDOWN_VALIDATION.md
+++ b/docs/MARKDOWN_VALIDATION.md
@@ -16,4 +16,4 @@ Para validar un archivo específico puedes usar `npx markdownlint-cli2 "path/to/
 
 Configuración y contexto
 
-La motivación y la configuración completa están documentadas en el ADR: [docs/adr/009-markdown-validation.md](docs/adr/009-markdown-validation.md)
+La motivación y la configuración completa están documentadas en el ADR: [docs/adr/009-markdown-validation.md](adr/009-markdown-validation.md)

--- a/docs/MARKDOWN_VALIDATION.md
+++ b/docs/MARKDOWN_VALIDATION.md
@@ -1,71 +1,19 @@
 # Markdownlint: Validación de Markdown
+Este documento contiene los comandos mínimos para validar Markdown en el proyecto.
 
-Este documento explica cómo usar `markdownlint` en el proyecto para asegurar formato consistente en archivos Markdown.
+Comandos
 
-## Propósito
+- Validar: `npm run lint:md`
+- Corregir automáticamente: `npm run lint:md:fix`
 
-`markdownlint` valida la estructura y formato de archivos Markdown, evitando errores comunes como:
+Nota CI
 
-- Encabezados inconsistentes
-- Código sin fences adecuados
-- Line endings/whitespace inconsistente
-- URLs desnudas sin formato de enlace
-- Listas inconsistentes
+El CI ejecuta `npm run lint` (que incluye `lint:md`).
 
-Aplicar estas reglas de forma reproducible reduce el ruido en PRs y mejora la calidad de la documentación.
+Validación puntual
 
-## Uso local
+Para validar un archivo específico puedes usar `npx markdownlint-cli2 "path/to/file.md"`.
 
-### Validar archivos
+Configuración y contexto
 
-```bash
-npm run lint:md
-```
-
-Valida todos los archivos `.md` contra la configuración unificada.
-
-### Corregir automáticamente
-
-```bash
-npm run lint:md:fix
-```
-
-Arregla automáticamente los problemas que se puedan corregir (espacios, formatos básicos, etc).
-
-### Validación específica
-
-Para validar un archivo o carpeta específica:
-
-```bash
-npx markdownlint-cli2 "path/to/file.md"
-npx markdownlint-cli2 "docs/**/*.md"
-```
-
-## Integración con CI/CD
-
-El script `lint:md` se ejecuta como parte del flujo de CI usando la misma configuración unificada.
-Los warnings se reportan pero no fallan la compilación, mientras que los errores fallan la validación.
-
-## Configuración de reglas
-
-Las reglas se documentan en `.markdownlint.jsonc` con comentarios explicativos.
-Para más detalles sobre reglas específicas, ver la [documentación de markdownlint](https://github.com/DavidAnson/markdownlint).
-
-## Flujo de trabajo recomendado
-
-1. **Antes de hacer commit:** ejecuta `npm run lint:md:fix` para corregir errores automáticos
-2. **Si hay errores manualmente:** revisa la salida de `npm run lint:md` para ajustes manuales
-3. **En PRs:** el CI valida automáticamente con `npm run lint:md`
-4. **Problemas persistentes:** abre un issue documentando la excepción necesaria
-
-## Excepciones justificadas
-
-Si necesitas una excepción a una regla en un archivo específico, puedes usar comentarios inline:
-
-```markdown
-<!-- markdownlint-disable MD034 -->
-https://example.com (URL desnuda, excepcionalmente permitida)
-<!-- markdownlint-enable MD034 -->
-```
-
-Documenta la razón de la excepción en el archivo o en un comentario del PR.
+La motivación y la configuración completa están documentadas en el ADR: [docs/adr/009-markdown-validation.md](docs/adr/009-markdown-validation.md)

--- a/docs/MARKDOWN_VALIDATION.md
+++ b/docs/MARKDOWN_VALIDATION.md
@@ -1,0 +1,71 @@
+# Markdownlint: Validación de Markdown
+
+Este documento explica cómo usar `markdownlint` en el proyecto para asegurar formato consistente en archivos Markdown.
+
+## Propósito
+
+`markdownlint` valida la estructura y formato de archivos Markdown, evitando errores comunes como:
+
+- Encabezados inconsistentes
+- Código sin fences adecuados
+- Line endings/whitespace inconsistente
+- URLs desnudas sin formato de enlace
+- Listas inconsistentes
+
+Aplicar estas reglas de forma reproducible reduce el ruido en PRs y mejora la calidad de la documentación.
+
+## Uso local
+
+### Validar archivos
+
+```bash
+npm run lint:md
+```
+
+Valida todos los archivos `.md` contra la configuración unificada.
+
+### Corregir automáticamente
+
+```bash
+npm run lint:md:fix
+```
+
+Arregla automáticamente los problemas que se puedan corregir (espacios, formatos básicos, etc).
+
+### Validación específica
+
+Para validar un archivo o carpeta específica:
+
+```bash
+npx markdownlint-cli2 'path/to/file.md'
+npx markdownlint-cli2 'docs/**/*.md'
+```
+
+## Integración con CI/CD
+
+El script `lint:md` se ejecuta como parte del flujo de CI usando la misma configuración unificada.
+Los warnings se reportan pero no fallan la compilación, mientras que los errores fallan la validación.
+
+## Configuración de reglas
+
+Las reglas se documentan en `.markdownlint.jsonc` con comentarios explicativos.
+Para más detalles sobre reglas específicas, ver la [documentación de markdownlint](https://github.com/DavidAnson/markdownlint).
+
+## Flujo de trabajo recomendado
+
+1. **Antes de hacer commit:** ejecuta `npm run lint:md:fix` para corregir errores automáticos
+2. **Si hay errores manualmente:** revisa la salida de `npm run lint:md` para ajustes manuales
+3. **En PRs:** el CI valida automáticamente con `npm run lint:md`
+4. **Problemas persistentes:** abre un issue documentando la excepción necesaria
+
+## Excepciones justificadas
+
+Si necesitas una excepción a una regla en un archivo específico, puedes usar comentarios inline:
+
+```markdown
+<!-- markdownlint-disable MD034 -->
+https://example.com (URL desnuda, excepcionalmente permitida)
+<!-- markdownlint-enable MD034 -->
+```
+
+Documenta la razón de la excepción en el archivo o en un comentario del PR.

--- a/docs/adr/009-markdown-validation.md
+++ b/docs/adr/009-markdown-validation.md
@@ -1,6 +1,6 @@
 # ADR 009: Validación de Markdown (formato y sincronización de documentación)
 
-> **Estado:** Aceptado
+> **Estado:** Aceptada
 > **Fecha:** 2026-05-01
 > **Última actualización:** 2026-05-02
 > **Categoría:** Contenido / Tooling
@@ -23,40 +23,43 @@ que eviten correcciones manuales repetidas.
 
 ## Decisión
 
-Centralizar y automatizar la validación de Markdown
-en el pipeline de CI mediante `markdownlint-cli2` usando una **configuración única unificada**
-con niveles de severidad (`severity: "error"` y `severity: "warning"`).
+Adoptar y automatizar la validación de Markdown en el pipeline de CI mediante `markdownlint-cli2` separando responsabilidades:
 
-La herramienta se usará para aplicar reglas sintácticas y de estilo;
-la validación semántica del frontmatter seguirá siendo
-responsabilidad de las content collections en build time.
+- Un archivo de reglas principal: `.markdownlint.jsonc` (define reglas y severity)
+- Un archivo orientado a CLI/CI: `.markdownlint-cli2.jsonc`
+  o un archivo de patrones/exclusiones (globs/ignores) que controla qué ficheros valida la CI
 
-### Configuración unificada con severity levels
+Esta separación permite mantener las reglas como fuente de verdad
+mientras se adapta qué se valida en CI sin modificar las reglas mismas.
 
-La solución usa un único archivo de configuración (`.markdownlint.jsonc`) que especifica:
+### Configuración propuesta: reglas + patterns para CLI
 
-- **Sin `severity` (defecto `"error"`)**: Reglas que fallan tanto en local como en CI
-- **`severity: "warning"`**: Reglas que se reportan pero no bloquean la compilación
-  (útiles para excepciones justificadas en CI)
-- **`false`**: Reglas deshabilitadas
+Detalles:
 
-Esto elimina la necesidad de mantener dos configuraciones separadas.
+- **`.markdownlint.jsonc`**: contiene las reglas, niveles de `severity` (`error`/`warning`)
+  y deshabilitaciones puntuales
+- **`.markdownlint-cli2.jsonc` / patterns`**: contiene globs/exclusiones
+  usados por el pipeline (por ejemplo para evitar validar ficheros generados o paths large)
+
+Las reglas se siguen aplicando en local y en CI; los patterns determinan el alcance en cada entorno.
 
 ## Implementación
 
-- Crear un único archivo `.markdownlint.jsonc` con severity levels
+- Crear dos archivos de configuración:
+  - `.markdownlint.jsonc` — reglas y `severity`
+  - `.markdownlint-cli2.jsonc` — globs/exclusiones y opciones específicas de CI/CLI
 - Añadir scripts en `package.json`:
-  - `npm run lint:md`: Validar archivos Markdown
+  - `npm run lint:md`: Validar archivos Markdown (usa `.markdownlint-cli2.jsonc` en CI)
   - `npm run lint:md:fix`: Corregir automáticamente
-- Documentar en `docs/MARKDOWN_VALIDATION.md` las reglas aplicadas y cómo usarlas
+- Documentar en `docs/MARKDOWN_VALIDATION.md` las reglas, patrones y cómo usarlos
 - El script `npm run lint` integra `lint:md` como parte del flujo de validación
 
 ## Alternativas consideradas
 
-- **Dos configuraciones separadas** (`.markdownlint.jsonc` y `.markdownlint-ci.jsonc`):
-  - ❌ Ventaja: flexibilidad máxima
-  - ❌ Desventaja: duplicación, complejidad, riesgo de desincronización
-  - ❌ Rechazado en favor de severity levels
+- **Dos configuraciones separadas** (`.markdownlint.jsonc` y `.markdownlint-cli2.jsonc`):
+  - ✅ Ventaja: flexibilidad para CI sin modificar reglas
+  - ⚠️ Desventaja: riesgo de desincronización si no se documenta
+  - ✅ Decisión adoptada: separar reglas y patterns, con documentación y checks de sincronización
 
 - **Solo linters en editor**:
   - Reduce errores locales pero no garantiza calidad en CI
@@ -64,16 +67,14 @@ Esto elimina la necesidad de mantener dos configuraciones separadas.
 - **Validación en pre-commit**:
   - Útil, pero puede omitirse en merges externos
 
-- **Validación unificada en CI/local (elegida)**:
-  - ✅ Garantiza que el sitio no se publica con errores
-  - ✅ Centraliza las reglas en un único archivo
-  - ✅ Usa severity levels para flexibilidad controlada
+- **Validación unificada en CI/local (rechazada)**:
+  - ❌ Rechazada por no permitir adaptar el alcance de la validación en CI sin tocar reglas
 
 ## Criterios de aceptación
 
 - [x] `npm run lint:md` está documentado y ejecutable localmente
 - [x] `npm run lint:md:fix` funciona para corregir automáticamente
-- [x] Un único archivo `.markdownlint.jsonc` con severity levels
+- [x] Existen los archivos `.markdownlint.jsonc` (reglas) y `.markdownlint-cli2.jsonc` (patterns/CLI)
 - [x] Integración en CI mediante `npm run lint` (que incluye `lint:md`)
 - [x] Documentación en `docs/MARKDOWN_VALIDATION.md` explicando reglas y uso
 - [x] La decisión de unificación queda documentada en este ADR (ADR 009)
@@ -88,9 +89,9 @@ Esto elimina la necesidad de mantener dos configuraciones separadas.
 
 ## Notas operativas
 
-- Mantener un único fichero de configuración: `.markdownlint.jsonc`
+- Mantener un único fichero de configuración para las reglas: `.markdownlint.jsonc`
+- Mantener un único fichero de configuración para las opciones de linea de comando: `.markdownlint-cli2.jsonc`
 - Usar severity levels para controlar qué falla y qué se reporta
-- Actualizar reglas según necesidad; documentar cambios en PRs
 
 ## Pasos futuros
 

--- a/docs/adr/009-markdown-validation.md
+++ b/docs/adr/009-markdown-validation.md
@@ -33,7 +33,7 @@ archivos serán consumidos por CI cuando el pipeline ejecute `markdownlint-cli2`
 - Añadir scripts en `package.json`:
   - `npm run lint:md` — validar (usado en CI y local)
   - `npm run lint:md:fix` — correcciones automáticas
-- Documentar en `docs/MARKDOWN_VALIDATION.md` los comandos mínimos y enlace al ADR
+- Documentar en [docs/MARKDOWN_VALIDATION.md](../MARKDOWN_VALIDATION.md) los comandos mínimos y enlace al ADR
 
 ## Alternativas consideradas
 

--- a/docs/adr/009-markdown-validation.md
+++ b/docs/adr/009-markdown-validation.md
@@ -1,12 +1,13 @@
 # ADR 009: Validación de Markdown (formato y sincronización de documentación)
 
-> **Estado:** Propuesta
+> **Estado:** Aceptado
 > **Fecha:** 2026-05-01
+> **Última actualización:** 2026-05-02
 > **Categoría:** Contenido / Tooling
 ---
 
-**Alcance:** Este ADR se limita a la adopción e integración inicial de `markdownlint-cli2`
-como herramienta de validación sintáctica y de estilo de Markdown en CI.
+**Alcance:** Este ADR cubre la adopción e integración de `markdownlint-cli2`
+como herramienta de validación sintáctica y de estilo de Markdown en CI y local.
 La gobernanza de la documentación
 (clasificación de anexos, políticas de archivado, owners y procesos de revisión)
 queda fuera del alcance de este ADR y se tratará en un ADR o issue separados.
@@ -23,68 +24,77 @@ que eviten correcciones manuales repetidas.
 ## Decisión
 
 Centralizar y automatizar la validación de Markdown
-en el pipeline de CI mediante `markdownlint-cli2`.
+en el pipeline de CI mediante `markdownlint-cli2` usando una **configuración única unificada**
+con niveles de severidad (`severity: "error"` y `severity: "warning"`).
+
 La herramienta se usará para aplicar reglas sintácticas y de estilo;
 la validación semántica del frontmatter seguirá siendo
 responsabilidad de las content collections en build time.
 
-## Implementación mínima inicial
+### Configuración unificada con severity levels
 
-- Añadir y publicar una configuración local estricta: `.markdownlint.jsonc`
-(para uso de desarrolladores)
-- Añadir y publicar una configuración para CI con excepciones documentadas:
-`.markdownlint-ci.jsonc`
-- Añadir scripts en `package.json`: `npm run lint:md` (local, estricto) y
-`npm run lint:md:ci` (CI con excepciones)
-- Documentar en `docs/` la lista de reglas aplicadas, globs/ignores y cómo usar `--fix`
-- Registrar las tareas y deuda en issues de GitHub:
-ver los issues referenciados en Plan de acción
+La solución usa un único archivo de configuración (`.markdownlint.jsonc`) que especifica:
 
-Nota: la validación semántica del frontmatter (presencia/formatos de `title`, `date`, etc.)
-queda fuera del alcance de este ADR.
+- **Sin `severity` (defecto `"error"`)**: Reglas que fallan tanto en local como en CI
+- **`severity: "warning"`**: Reglas que se reportan pero no bloquean la compilación
+  (útiles para excepciones justificadas en CI)
+- **`false`**: Reglas deshabilitadas
+
+Esto elimina la necesidad de mantener dos configuraciones separadas.
+
+## Implementación
+
+- Crear un único archivo `.markdownlint.jsonc` con severity levels
+- Añadir scripts en `package.json`:
+  - `npm run lint:md`: Validar archivos Markdown
+  - `npm run lint:md:fix`: Corregir automáticamente
+- Documentar en `docs/MARKDOWN_VALIDATION.md` las reglas aplicadas y cómo usarlas
+- El script `npm run lint` integra `lint:md` como parte del flujo de validación
 
 ## Alternativas consideradas
 
-- Solo linters en editor: reduce errores locales pero no garantiza calidad en CI
-- Validación en pre-commit: útil, pero puede omitirse en merges externos
-- Validación en CI (elegida): garantiza que el sitio no se publica con errores
-  y centraliza las reglas
+- **Dos configuraciones separadas** (`.markdownlint.jsonc` y `.markdownlint-ci.jsonc`):
+  - ❌ Ventaja: flexibilidad máxima
+  - ❌ Desventaja: duplicación, complejidad, riesgo de desincronización
+  - ❌ Rechazado en favor de severity levels
+
+- **Solo linters en editor**:
+  - Reduce errores locales pero no garantiza calidad en CI
+
+- **Validación en pre-commit**:
+  - Útil, pero puede omitirse en merges externos
+
+- **Validación unificada en CI/local (elegida)**:
+  - ✅ Garantiza que el sitio no se publica con errores
+  - ✅ Centraliza las reglas en un único archivo
+  - ✅ Usa severity levels para flexibilidad controlada
 
 ## Criterios de aceptación
 
-- `npm run lint:md` está documentado y ejecutable localmente (configuración estricta)
-- CI ejecuta `npm run lint:md:ci` y reporta resultados
-- Las decisiones de endurecimiento y eliminación de excepciones
-  están registradas en los issues correspondientes (véase Plan)
-- Documentación en `docs/` que explica cómo corregir fallos y usar `--fix`
-
-## Plan de acción (issues)
-
-1. Issue **#139 — Configuración inicial markdownlint**: añadir ambas configuraciones
-  (`.markdownlint.jsonc` y `.markdownlint-ci.jsonc`)
-  y los scripts `lint:md` / `lint:md:ci`, junto con documentación mínima.
-2. Issue **#140 — Unificar reglas de configuración de markdownlint**:
-  auditar excepciones y planificar la convergencia entre CI y local; eliminar excepciones no justificadas por fases.
-3. Implementar cada issue mediante PRs que referencien su issue correspondiente
-  para mantener trazabilidad.
+- [x] `npm run lint:md` está documentado y ejecutable localmente
+- [x] `npm run lint:md:fix` funciona para corregir automáticamente
+- [x] Un único archivo `.markdownlint.jsonc` con severity levels
+- [x] Integración en CI mediante `npm run lint` (que incluye `lint:md`)
+- [x] Documentación en `docs/MARKDOWN_VALIDATION.md` explicando reglas y uso
+- [x] ADR de referencia (ADR 010) documentando la decisión de unificación
 
 ## Riesgos y mitigaciones
 
-- Fricción para contribuyentes: ofrecer `--fix` y ejemplos de corrección;
-  periodo de advertencia antes de bloquear merges
-- Reglas incompletas o demasiado estrictas: desplegar configuración laxa en CI inicialmente
-  y endurecer por iteraciones planificadas
+- **Riesgo**: Fricción para contribuyentes por nuevas reglas
+  - **Mitigación**: Ofrecer `npm run lint:md:fix`, documentación clara y ejemplos
+
+- **Riesgo**: Warnings no se revisan en CI
+  - **Mitigación**: Los warnings aparecen en logs; se revisan en PRs
 
 ## Notas operativas
 
-- Mantener dos ficheros de reglas: `.markdownlint.jsonc` (local, estricto)
-  y `.markdownlint-ci.jsonc` (CI con excepciones revisables)
-- Usar `.markdownlint-cli2.jsonc` para opciones del CLI (globs/ignores) si procede
-- Registrar la deuda y el plan de endurecimiento en `#140`
-  y actualizar este ADR con enlaces a los issues cuando estén abiertos
+- Mantener un único fichero de configuración: `.markdownlint.jsonc`
+- Usar severity levels para controlar qué falla y qué se reporta
+- Actualizar reglas según necesidad; documentar cambios en PRs
 
-## Limitaciones y pasos futuros
+## Pasos futuros
 
-- Pendiente: normalizar formato y consistencia de los ADRs en `docs/adr/` (trabajo futuro)
-- Prioridad: desplegar la solución mínima
-  y recopilar ejemplos reales antes de ampliar validaciones
+- Documentación regla-por-regla detallada (ejemplos de fallos, cómo corregir)
+- Auditar excepciones según sea necesario
+- Endurecer reglas (cambiar warnings a errors) por iteraciones planificadas
+- Considerar extensiones de markdownlint (plugins) si fuese necesario

--- a/docs/adr/009-markdown-validation.md
+++ b/docs/adr/009-markdown-validation.md
@@ -76,7 +76,7 @@ Esto elimina la necesidad de mantener dos configuraciones separadas.
 - [x] Un único archivo `.markdownlint.jsonc` con severity levels
 - [x] Integración en CI mediante `npm run lint` (que incluye `lint:md`)
 - [x] Documentación en `docs/MARKDOWN_VALIDATION.md` explicando reglas y uso
-- [x] ADR de referencia (ADR 010) documentando la decisión de unificación
+- [x] La decisión de unificación queda documentada en este ADR (ADR 009)
 
 ## Riesgos y mitigaciones
 

--- a/docs/adr/009-markdown-validation.md
+++ b/docs/adr/009-markdown-validation.md
@@ -7,10 +7,7 @@
 ---
 
 **Alcance:** Este ADR cubre la adopción e integración de `markdownlint-cli2`
-como herramienta de validación sintáctica y de estilo de Markdown en CI y local.
-La gobernanza de la documentación
-(clasificación de anexos, políticas de archivado, owners y procesos de revisión)
-queda fuera del alcance de este ADR y se tratará en un ADR o issue separados.
+como herramienta de validación sintáctica y de estilo de Markdown.
 
 ## Contexto
 
@@ -23,26 +20,22 @@ que eviten correcciones manuales repetidas.
 
 ## Decisión
 
-Usar dos archivos con responsabilidades separadas:
-
-- `.markdownlint.jsonc`: reglas y niveles de `severity` (fuente de verdad)
-- `.markdownlint-cli2.jsonc` (opcional): patterns/globs/exclusiones y opciones de ejecución para la CLI/CI
-
-`npm run lint:md` invoca `markdownlint-cli2` y, si existe, aplica las opciones de `.markdownlint-cli2.jsonc`; CI usa el mismo script. No se usarán archivos distintos de reglas para local y CI: la configuración de reglas debe mantenerse sincronizada.
+Usar `markdownlint-cli2` con un archivo de reglas (`.markdownlint.jsonc`)
+y un archivo de opciones para la CLI (`.markdownlint-cli2.jsonc`) que controle patterns/exclusiones; ambos
+archivos serán consumidos por CI cuando el pipeline ejecute `markdownlint-cli2` (por ejemplo vía
+`npm run lint:md`), de modo que las mismas reglas se apliquen en CI y localmente.
 
 ## Implementación
 
-- Crear dos archivos de configuración:
+- Mantener dos archivos de configuración consumidos por CI y localmente:
   - `.markdownlint.jsonc` — reglas y `severity`
-  - `.markdownlint-cli2.jsonc` — globs/exclusiones y opciones específicas de CI/CLI
+  - `.markdownlint-cli2.jsonc` — globs/exclusiones y opciones de ejecución
 - Añadir scripts en `package.json`:
-  - `npm run lint:md`: Validar archivos Markdown (usa `.markdownlint-cli2.jsonc` en CI)
-  - `npm run lint:md:fix`: Corregir automáticamente
-- Documentar en `docs/MARKDOWN_VALIDATION.md` las reglas, patrones y cómo usarlos
-- El script `npm run lint` integra `lint:md` como parte del flujo de validación
+  - `npm run lint:md` — validar (usado en CI y local)
+  - `npm run lint:md:fix` — correcciones automáticas
+- Documentar en `docs/MARKDOWN_VALIDATION.md` los comandos mínimos y enlace al ADR
 
 ## Alternativas consideradas
-
 
 - **Dos archivos de reglas distintas (local vs CI)**:
   - ❌ Rechazada: provoca deriva de reglas y bloqueos inesperados
@@ -53,40 +46,12 @@ Usar dos archivos con responsabilidades separadas:
   - ⚠️ Desventaja: requiere documentación y controles para evitar confusiones
 
 - **Solo linters en editor**:
-  - Reduce errores locales pero no garantiza calidad en CI
-
-- **Validación en pre-commit**:
-  - Útil, pero puede omitirse en merges externos
-
-- **Validación unificada en CI/local (rechazada)**:
-  - ❌ Rechazada por no permitir adaptar el alcance de la validación en CI sin tocar reglas
+  - ❌ Rechazada: reduce errores locales pero no garantiza calidad en CI
+  - ⚠️ Desventaja: depende de la configuración individual y no es obligatorio en CI
 
 ## Criterios de aceptación
 
-- [x] `npm run lint:md` está documentado y ejecutable localmente
-- [x] `npm run lint:md:fix` funciona para corregir automáticamente
-- [x] Existen los archivos `.markdownlint.jsonc` (reglas) y `.markdownlint-cli2.jsonc` (patterns/CLI)
-- [x] Integración en CI mediante `npm run lint` (que incluye `lint:md`)
-- [x] Documentación en `docs/MARKDOWN_VALIDATION.md` explicando reglas y uso
-- [x] La decisión de unificación queda documentada en este ADR (ADR 009)
-
-## Riesgos y mitigaciones
-
-- **Riesgo**: Fricción para contribuyentes por nuevas reglas
-  - **Mitigación**: Ofrecer `npm run lint:md:fix`, documentación clara y ejemplos
-
-- **Riesgo**: Warnings no se revisan en CI
-  - **Mitigación**: Los warnings aparecen en logs; se revisan en PRs
-
-## Notas operativas
-
-- Mantener un único fichero de configuración para las reglas: `.markdownlint.jsonc`
-- Mantener un único fichero de configuración para las opciones de linea de comando: `.markdownlint-cli2.jsonc`
-- Usar severity levels para controlar qué falla y qué se reporta
-
-## Pasos futuros
-
-- Documentación regla-por-regla detallada (ejemplos de fallos, cómo corregir)
-- Auditar excepciones según sea necesario
-- Endurecer reglas (cambiar warnings a errors) por iteraciones planificadas
-- Considerar extensiones de markdownlint (plugins) si fuese necesario
+- `npm run lint:md` y `npm run lint:md:fix` funcionan localmente
+- `.markdownlint.jsonc` existe y contiene reglas con `severity`
+- `.markdownlint-cli2.jsonc` contiene las reglas de ejecución, por ejemplo patrones a ignorar
+- `docs/MARKDOWN_VALIDATION.md` muestra los comandos mínimos y enlaza al ADR

--- a/docs/adr/009-markdown-validation.md
+++ b/docs/adr/009-markdown-validation.md
@@ -23,25 +23,12 @@ que eviten correcciones manuales repetidas.
 
 ## Decisión
 
-Adoptar y automatizar la validación de Markdown en el pipeline de CI mediante `markdownlint-cli2` separando responsabilidades:
+Usar dos archivos con responsabilidades separadas:
 
-- Un archivo de reglas principal: `.markdownlint.jsonc` (define reglas y severity)
-- Un archivo orientado a CLI/CI: `.markdownlint-cli2.jsonc`
-  o un archivo de patrones/exclusiones (globs/ignores) que controla qué ficheros valida la CI
+- `.markdownlint.jsonc`: reglas y niveles de `severity` (fuente de verdad)
+- `.markdownlint-cli2.jsonc` (opcional): patterns/globs/exclusiones y opciones de ejecución para la CLI/CI
 
-Esta separación permite mantener las reglas como fuente de verdad
-mientras se adapta qué se valida en CI sin modificar las reglas mismas.
-
-### Configuración propuesta: reglas + patterns para CLI
-
-Detalles:
-
-- **`.markdownlint.jsonc`**: contiene las reglas, niveles de `severity` (`error`/`warning`)
-  y deshabilitaciones puntuales
-- **`.markdownlint-cli2.jsonc` / patterns`**: contiene globs/exclusiones
-  usados por el pipeline (por ejemplo para evitar validar ficheros generados o paths large)
-
-Las reglas se siguen aplicando en local y en CI; los patterns determinan el alcance en cada entorno.
+`npm run lint:md` invoca `markdownlint-cli2` y, si existe, aplica las opciones de `.markdownlint-cli2.jsonc`; CI usa el mismo script. No se usarán archivos distintos de reglas para local y CI: la configuración de reglas debe mantenerse sincronizada.
 
 ## Implementación
 
@@ -56,10 +43,14 @@ Las reglas se siguen aplicando en local y en CI; los patterns determinan el alca
 
 ## Alternativas consideradas
 
-- **Dos configuraciones separadas** (`.markdownlint.jsonc` y `.markdownlint-cli2.jsonc`):
-  - ✅ Ventaja: flexibilidad para CI sin modificar reglas
-  - ⚠️ Desventaja: riesgo de desincronización si no se documenta
-  - ✅ Decisión adoptada: separar reglas y patterns, con documentación y checks de sincronización
+
+- **Dos archivos de reglas distintas (local vs CI)**:
+  - ❌ Rechazada: provoca deriva de reglas y bloqueos inesperados
+  - ❌ Motivo: `severity` permite la flexibilidad necesaria sin duplicar reglas
+
+- **Separar reglas vs patterns/CLI (adoptada)** (`.markdownlint.jsonc` + `.markdownlint-cli2.jsonc`):
+  - ✅ Ventaja: reglas centralizadas y patterns ajustables por entorno
+  - ⚠️ Desventaja: requiere documentación y controles para evitar confusiones
 
 - **Solo linters en editor**:
   - Reduce errores locales pero no garantiza calidad en CI

--- a/docs/adr/009-markdown-validation.md
+++ b/docs/adr/009-markdown-validation.md
@@ -31,7 +31,7 @@ archivos serán consumidos por CI cuando el pipeline ejecute `markdownlint-cli2`
   - `.markdownlint.jsonc` — reglas y `severity`
   - `.markdownlint-cli2.jsonc` — globs/exclusiones y opciones de ejecución
 - Añadir scripts en `package.json`:
-  - `npm run lint:md` — validar (usado en CI y local)
+  - `npm run lint:md` — validar markdown
   - `npm run lint:md:fix` — correcciones automáticas
 - Documentar en [docs/MARKDOWN_VALIDATION.md](../MARKDOWN_VALIDATION.md) los comandos mínimos y enlace al ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,7 +15,7 @@ anteriores (`secorto.com_jekyll`, `web2021`). Documentan la evolución
 completa del proyecto a través de tres reescrituras en diferentes frameworks.
 
 | # | Título | Estado | Fecha original |
-|---|--------|--------|----------------|
+| --- | --- | --- | --- |
 | [R01](R01-fundacion-sitio-jekyll.md) | Fundación del sitio personal con Jekyll | Reemplazada → R02 | 2016-04 |
 | [R02](R02-migracion-jekyll-a-gatsby.md) | Migración de Jekyll a Gatsby | Reemplazada → R03 | 2021-03 |
 | [R03](R03-migracion-gatsby-a-astro.md) | Migración de Gatsby a Astro | Aceptada | 2024-05 |
@@ -23,12 +23,16 @@ completa del proyecto a través de tres reescrituras en diferentes frameworks.
 ### ADRs del proyecto actual
 
 | # | Título | Estado | Fecha |
-|---|--------|--------|-------|
+| --- | --- | --- | --- |
 | [001](001-i18n-router-framework.md) | Framework i18n y router polimórfico de secciones | Aceptada | 2025-06 |
 | [002](002-testing-framework-migration.md) | Migración de Cypress a Playwright + Vitest | Aceptada | 2025-07 |
 | [003](003-third-party-mocks.md) | Mocks de servicios de terceros en tests E2E | Aceptada | 2025-07 |
 | [004](004-linting-any-ban-style-conventions.md) | Linting, prohibición de `any` y convenciones de estilo | Parcial | 2025-07 |
 | [005](005-copilot-subscription-proposal.md) | Propuesta: suscripción a GitHub Copilot | Propuesta | 2025-07 |
+| [006](006-unificacion-manejo-borradores.md) | Unificación del manejo de borradores (`draft`) | Aceptada | 2026-02 |
+| [007](007-domain-i18n-unificacion.md) | Unificación de dominio e i18n — `postId`, mapas de locales y SEO centralizado | Aceptada | 2026-03 |
+| [008](008-client-scripts-unit-testing.md) | Estrategia de pruebas client-side y reorganización del cliente | Aceptada | 2026-04 |
+| [009](009-markdown-validation.md) | Validación de Markdown (formato y sincronización de documentación) | Propuesta | 2026-05 |
 
 ## Convenciones
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secorto-website",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secorto-website",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "dependencies": {
         "@astrojs/check": "^0.9.8",
         "@astrojs/rss": "^4.0.18",
@@ -33,6 +33,7 @@
         "eslint-plugin-astro": "^1.7.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
+        "markdownlint-cli2": "^0.22.1",
         "vitest": "^4.1.4"
       },
       "engines": {
@@ -2469,6 +2470,19 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2539,6 +2553,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4409,6 +4430,17 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6624,6 +6656,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6780,6 +6825,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globby/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -7348,6 +7437,32 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -7500,6 +7615,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -7578,6 +7704,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -8147,6 +8284,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jsprim": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
@@ -8177,6 +8324,33 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {
@@ -8229,6 +8403,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/listr2": {
@@ -8470,6 +8654,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -8479,6 +8681,77 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
+      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globby": "16.2.0",
+        "js-yaml": "4.1.1",
+        "jsonc-parser": "3.3.1",
+        "jsonpointer": "5.0.1",
+        "markdown-it": "14.1.1",
+        "markdownlint": "0.40.0",
+        "markdownlint-cli2-formatter-default": "0.0.6",
+        "micromatch": "4.0.8",
+        "smol-toml": "1.6.1"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      },
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -8733,6 +9006,13 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8815,6 +9095,26 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -8928,6 +9228,26 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -9292,9 +9612,9 @@
       ]
     },
     "node_modules/micromark-util-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
-      "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -9304,7 +9624,8 @@
           "type": "OpenCollective",
           "url": "https://opencollective.com/unified"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9845,6 +10166,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -10190,6 +10538,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11088,6 +11446,19 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -11199,6 +11570,52 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="
+    },
+    "node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -11791,6 +12208,13 @@
         "semver": "^7.3.8"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -11842,6 +12266,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "test:unit": "vitest",
     "test:unit:watch": "vitest --watch",
     "test:unit:ui": "vitest --ui",
-    "lint": "eslint ."
+    "lint": "npm run lint:md && npm run lint:js",
+    "lint:js": "eslint .",
+    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "lint:md:fix": "markdownlint-cli2 \"**/*.md\" --fix"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.8",
@@ -46,6 +49,7 @@
     "eslint-plugin-astro": "^1.7.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
+    "markdownlint-cli2": "^0.22.1",
     "vitest": "^4.1.4"
   }
 }


### PR DESCRIPTION
* Instalación markdownlint-cli2
* Actualización ADR-009 pasa a Aceptado
* Reglas fallando marcadas como severity warning
* Creado documento Markdown validation
* Actualizado lint para ejecutar tanto la verificación de md como la de js, dado que la de md es mas ruidosa la de js se dejo al final

# Pull request

Closes #139 

## Observaciones

#140 permanecera abierto como la sombrilla a los fixes incrementales que se hara sobre la configuración del linter y solo se cerrara cuando se llegue a la versión final de las  reglas, la idea del alcance actuales implementar algo minimalista para desbloquear la revisión de contenido que debe ser evaluado en ADR-010 que pasa a ser la proxima propuesta a implementar
