### PR TITLE
Cambio de contenido ahora tags son obligatorias

### DIFF
--- a/src/components/BlogTalkPostView.astro
+++ b/src/components/BlogTalkPostView.astro
@@ -14,7 +14,7 @@ interface Props {
     data: {
       title: string
       date?: Date
-      tags?: string[]
+      tags: string[]
       image?: string | ImageMetadata
       excerpt?: string
       gallery?: Array<{ image: ImageMetadata; alt: string }>
@@ -30,9 +30,7 @@ const t = useTranslations(locale)
 const dateFormat = getFullFormat(Astro.url)
 ---
 
-{entry.data.tags && entry.data.tags.length > 0 && (
-  <Tags route={`/${locale}/${routeSlug}/tags/`} tags={entry.data.tags} />
-)}
+<Tags route={`/${locale}/${routeSlug}/tags/`} tags={entry.data.tags} />
 
 {entry.data.video &&
     <ResponsiveIframe

--- a/src/components/WorkProjectCommunityView.astro
+++ b/src/components/WorkProjectCommunityView.astro
@@ -5,11 +5,11 @@ import WorkDateRange from '@components/WorkDateRange.astro'
 import { useTranslations } from '@i18n/utils'
 import type { UILanguages } from '@i18n/ui'
 import type { RenderResult } from 'astro:content'
+import Tags from './Tags.astro'
 
 interface Props {
   locale: UILanguages
-  /** Slug de ruta de la sección (solo lo usa BlogTalkPostView; aceptado aquí para call-site uniforme desde [...id].astro) */
-  routeSlug?: string
+  routeSlug: string
   entry: {
     data: {
       title: string
@@ -21,14 +21,17 @@ interface Props {
       startDate?: Date
       endDate?: Date
       gallery?: Array<{ image: ImageMetadata; alt: string }>
+      tags: string[]
     }
   }
   Content: RenderResult['Content']
 }
 
-const { locale, entry, Content } = Astro.props
+const { locale, entry, Content, routeSlug } = Astro.props
 const t = useTranslations(locale)
 ---
+
+<Tags route={`/${locale}/${routeSlug}/tags/`} tags={entry.data.tags} />
 
 {entry.data?.image && (
   typeof entry.data.image === 'string' ? (

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,6 +8,7 @@ import { glob } from 'astro/loaders'
  */
 const createBasePostSchema = (imageHelper: ImageFunction) => z.object({
   title: z.string(),
+  tags: z.array(z.string()).nonempty('Tags are required'),
   image: imageHelper().optional(),
   excerpt: z.string().optional(),
   description: z.string().optional(),
@@ -15,7 +16,6 @@ const createBasePostSchema = (imageHelper: ImageFunction) => z.object({
   translationKey: z.string().optional(),
   canonical: z.boolean().optional(),
   draft: z.boolean().optional(),
-  tags: z.array(z.string()).optional(),
   gallery: z.array(z.object({
     image: imageHelper(),
     alt: z.string()

--- a/src/content/blog/en/2026-04-25-my-first-steps-in-linux.md
+++ b/src/content/blog/en/2026-04-25-my-first-steps-in-linux.md
@@ -3,7 +3,6 @@ title: My first steps in Linux
 date: 2026-04-25
 tags:
   - linux
-  - summary
   - experiences
 excerpt: A concise personal roundup of lessons learned using several distributions and desktop environments.
 gallery:

--- a/src/content/blog/es/2026-04-25-mis-primeros-pasos-en-linux.md
+++ b/src/content/blog/es/2026-04-25-mis-primeros-pasos-en-linux.md
@@ -3,7 +3,6 @@ title: Mis primeros pasos en Linux
 date: 2026-04-25
 tags:
   - linux
-  - resumen
   - experiencias
 excerpt: Un repaso personal y condensado de lo que aprendí usando varias distribuciones y entornos de escritorio, transformando antiguos tutoriales en lecciones.
 gallery:

--- a/src/content/community/en/free-software-barranquilla.md
+++ b/src/content/community/en/free-software-barranquilla.md
@@ -6,8 +6,6 @@ responsibilities: "Organization of free software events, talks on Linux and secu
 tags:
   - opensource
   - linux
-  - ubuntu
-  - flisol
 translationKey: fsl-barranquilla
 image: "@assets/img/comunidades/wp-baq.png"
 priority: 40

--- a/src/content/community/en/medellin-contributions.md
+++ b/src/content/community/en/medellin-contributions.md
@@ -8,6 +8,10 @@ location: medellin
 connection: "Python Colombia"
 priority: 35
 translationKey: medellin-contributions
+tags:
+  - jamstack
+  - frontend
+  - opensource
 ---
 
 My participation in Medellín emerged through **Python Colombia** (PyCon 2018–2024).

--- a/src/content/community/en/pybaq.md
+++ b/src/content/community/en/pybaq.md
@@ -16,6 +16,10 @@ gallery:
     image: "@assets/img/pybaq/pycon-pybaq-2019.jpg"
   - alt: Starting PyCon 2019
     image: "@assets/img/pybaq/pycon-entrada.jpg"
+tags:
+  - python
+  - testing
+  - opensource
 ---
 
 PyBAQ is part of **Python Colombia**, the national network of Python communities.

--- a/src/content/community/es/contribuciones-medellin.md
+++ b/src/content/community/es/contribuciones-medellin.md
@@ -6,6 +6,10 @@ role: "Speaker"
 responsibilities: "Charlas sobre tecnologías web y desarrollo moderno"
 priority: 35
 translationKey: medellin-contributions
+tags:
+  - jamstack
+  - frontend
+  - opensource
 ---
 
 Mi participación en Medellín surgió a través de **Python Colombia** (PyCon 2018–2024).

--- a/src/content/community/es/pybaq.md
+++ b/src/content/community/es/pybaq.md
@@ -16,6 +16,10 @@ gallery:
     image: "@assets/img/pybaq/pycon-pybaq-2019.jpg"
   - alt: Iniciando PyCon 2019
     image: "@assets/img/pybaq/pycon-entrada.jpg"
+tags:
+  - python
+  - testing
+  - opensource
 ---
 
 PyBAQ es parte de **Python Colombia**, la red nacional de comunidades Python.

--- a/src/content/community/es/software-libre-barranquilla.md
+++ b/src/content/community/es/software-libre-barranquilla.md
@@ -6,8 +6,6 @@ responsibilities: "Organización de eventos de software libre, charlas sobre Lin
 tags:
   - opensource
   - linux
-  - ubuntu
-  - flisol
 translationKey: fsl-barranquilla
 image: "@assets/img/comunidades/wp-baq.png"
 priority: 40


### PR DESCRIPTION
# Pull request

Habilitar mecanismo de tags en detalles de experiencia
Se fuerza que los tags deben estar presentes en todos los content types para evitar verificar si existen disminuyendo la complejidad accidental